### PR TITLE
Fix serialization of objects with PHP5.3+ namespaces (RT#97863)

### DIFF
--- a/lib/PHP/Serialization.pm
+++ b/lib/PHP/Serialization.pm
@@ -449,8 +449,7 @@ sub _encode {
     }
     elsif ( $type eq 'obj' ) {
         my $class = ref($val);
-        $class =~ /(\w+)$/;
-        my $subclass = $1;
+        my $subclass = (split "::", $class)[-1];
         $buffer .= sprintf('O:%d:"%s":%d:', length($subclass), $subclass, scalar(keys %{$val})) . '{';
         foreach ( %{$val} ) {
             $buffer .= $self->encode($_);

--- a/t/11namespaces.t
+++ b/t/11namespaces.t
@@ -1,0 +1,11 @@
+#!/usr/bin/env perl
+
+use Test::More tests => 1;
+
+use PHP::Serialization qw(unserialize serialize);
+
+my $encoded = q|O:7:"Foo\\Bar":1:{s:5:"value";i:1;}|;
+
+my $data = unserialize($encoded);
+is( ref $data, ref unserialize( serialize( $data )) );
+


### PR DESCRIPTION
Fix serialization of objects with PHP5.3+ namespaces (RT#97863)

https://rt.cpan.org/Ticket/Display.html?id=97863
